### PR TITLE
fix: 復習物編集モーダルの学習日変更検知が初期値に戻した際に正しく動作しない問題を修正

### DIFF
--- a/src/components/modals/EditItemModal.tsx
+++ b/src/components/modals/EditItemModal.tsx
@@ -97,7 +97,10 @@ export const EditItemModal = ({ isOpen, onClose, item }: EditItemModalProps) => 
     const originalLearnedDate = React.useMemo(() => new Date(item.learned_date), [item.learned_date]);
     const isLearnedDateChanged = React.useMemo(() => {
         if (!watchedLearnedDate) return false;
-        return watchedLearnedDate.getTime() !== originalLearnedDate.getTime();
+        // 時刻部分を無視して日付のみで比較（時刻による誤差を防ぐため）
+        const originalDateOnly = new Date(originalLearnedDate.getFullYear(), originalLearnedDate.getMonth(), originalLearnedDate.getDate());
+        const currentDateOnly = new Date(watchedLearnedDate.getFullYear(), watchedLearnedDate.getMonth(), watchedLearnedDate.getDate());
+        return originalDateOnly.getTime() !== currentDateOnly.getTime();
     }, [watchedLearnedDate, originalLearnedDate]);
 
     // データ取得: フォームの選択肢を生成するために必要


### PR DESCRIPTION
## 概要
復習物編集モーダルの学習日変更検知が初期値に戻した際に正しく動作しない問題を修正

## 変更内容
 - 時刻部分を無視して日付のみで比較するように変更
 - 初期状態の学習日に戻した場合にisLearnedDateChangedがfalseになるよう修正
 - これによりIsMarkOverdueAsCompletedが正しくfalseとしてリクエストされるようになった