### PR TITLE
Fix/#85/error msg int16

### DIFF
--- a/src/components/modals/CreatePatternModal.tsx
+++ b/src/components/modals/CreatePatternModal.tsx
@@ -102,6 +102,13 @@ export const CreatePatternModal = ({ isOpen, onClose }: CreatePatternModalProps)
             return;
         }
 
+        // ステップサイズチェック（32768以上）
+        const hasLargeStep = stepValues.some((value) => value >= 32768);
+        if (hasLargeStep) {
+            toast.error(t('pattern.steoSizeError'));
+            return;
+        }
+
         // APIが要求する形式にデータを整形する
         const data: CreatePatternRequest = {
             ...values,

--- a/src/components/modals/EditPatternModal.tsx
+++ b/src/components/modals/EditPatternModal.tsx
@@ -117,6 +117,12 @@ export const EditPatternModal = ({ isOpen, onClose, pattern }: EditPatternModalP
             toast.error(t('pattern.stepOrderError'));
             return;
         }
+        // ステップサイズチェック（32768以上）
+        const hasLargeStep = stepValues.some((value) => value >= 32768);
+        if (hasLargeStep) {
+            toast.error(t('pattern.steoSizeError'));
+            return;
+        }
         // 変更有無判定
         const isNameChanged = values.name !== pattern.name;
         const isWeightChanged = values.target_weight !== pattern.target_weight;

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -97,6 +97,7 @@
         "steps": "Steps",
         "duplicateStepError": "Steps are duplicated.",
         "stepOrderError": "Step order is incorrect.",
+        "steoSizeError": "Value is too large.",
         "heavy": "Heavy",
         "normal": "Normal",
         "light": "Light",

--- a/src/i18n/locales/ja.json
+++ b/src/i18n/locales/ja.json
@@ -98,6 +98,7 @@
         "steps": "ステップ",
         "duplicateStepError": "ステップが重複しています。",
         "stepOrderError": "ステップの順序が正しくありません。",
+        "steoSizeError": "値が大きすぎます。",
         "heavy": "Heavy",
         "normal": "Normal",
         "light": "Light",


### PR DESCRIPTION
## 概要
パターンステップの値がサーバー側でオーバーフローした場合のエラーメッセージで翻訳キーを使うように変更。

## 変更内容
- ステップの値が大きすぎる場合のトーストの翻訳キーを追加
- ステップの値が大きすぎる場合にエラーメッセージをトースト表示するように変更