### PR TITLE
fix: 復習物名のマス幅を変更

### DIFF
--- a/src/components/feature/Box.tsx
+++ b/src/components/feature/Box.tsx
@@ -65,7 +65,7 @@ export const Box = ({ items, isLoading, currentCategory, currentBox }: BoxProps)
     const [isCreateItemModalOpen, setCreateItemModalOpen] = React.useState(false);
 
     // --- State (復習物名列の幅調整) ---
-    const [nameColumnWidth, setNameColumnWidth] = React.useState(300);
+    const [nameColumnWidth, setNameColumnWidth] = React.useState(430);
     const [isResizing, setIsResizing] = React.useState(false);
     const [isHovering, setIsHovering] = React.useState(false);
     const [startX, setStartX] = React.useState(0);
@@ -143,7 +143,7 @@ export const Box = ({ items, isLoading, currentCategory, currentBox }: BoxProps)
     }, []);
 
     const handleResetWidth = () => {
-        setNameColumnWidth(300); // 初期値にリセット
+        setNameColumnWidth(430); // 初期値にリセット
     };
 
     React.useEffect(() => {

--- a/src/pages/App/TodaysReviewPage.tsx
+++ b/src/pages/App/TodaysReviewPage.tsx
@@ -126,7 +126,7 @@ const TodaysReviewPage = () => {
     const [editingReviewDate, seteditingReviewDate] = React.useState<{ item: ItemResponse; reviewDate: ReviewDateResponse } | null>(null);
 
     // (復習物名列の幅調整)
-    const [nameColumnWidth, setNameColumnWidth] = React.useState(300);
+    const [nameColumnWidth, setNameColumnWidth] = React.useState(420);
     const [isResizing, setIsResizing] = React.useState(false);
     const [isHovering, setIsHovering] = React.useState(false);
     const [startX, setStartX] = React.useState(0);
@@ -260,7 +260,7 @@ const TodaysReviewPage = () => {
     }, []);
 
     const handleResetWidth = () => {
-        setNameColumnWidth(300);
+        setNameColumnWidth(420);
     };
 
     React.useEffect(() => {


### PR DESCRIPTION
## 概要
#100 の対応。
復習物名のマス幅を300→420に変更。

##  関連
#101 を今後実装したい