### PR TITLE
Feat/#114/add support before login

### DIFF
--- a/src/components/layout/AuthLayout.tsx
+++ b/src/components/layout/AuthLayout.tsx
@@ -1,12 +1,23 @@
 import { Outlet } from 'react-router-dom';
-import { useAuthTexts } from '@/store/authLanguageStore';
+import { useAuthTexts, useAuthLanguageStore } from '@/store/authLanguageStore';
+import { QuestionMarkCircleIcon, ArrowTopRightOnSquareIcon } from '@heroicons/react/24/outline';
+import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 
 const AuthLayout = () => {
     // 未ログイン時専用の言語状態管理からテキストを取得
     const texts = useAuthTexts();
+    const language = useAuthLanguageStore((state) => state.language);
+
+    const handleContactClick = () => {
+        const contactUrl = language === 'ja'
+            ? 'https://docs.google.com/forms/d/e/1FAIpQLSfFw5rrigVARCM_B8T_dCaZagSenX-xjp41QUkqW2IncrgVEA/viewform?usp=header'
+            : 'https://docs.google.com/forms/d/e/1FAIpQLSf42zxGjMQaIahXiF-1XB7hI3Dz8V4xvRrRHdYDTJL4EXCvVg/viewform?usp=header';
+        window.open(contactUrl, '_blank');
+    };
 
     return (
-        <div className="flex min-h-screen w-full">
+        <div className="relative flex min-h-screen w-full">
             <div className="hidden lg:flex lg:flex-1 items-center justify-center bg-muted p-10">
                 <h1 className="text-3xl font-bold text-foreground/80">
                     {texts.serviceTitle}
@@ -18,6 +29,27 @@ const AuthLayout = () => {
                     {/* ここにLoginPageやSignupPageなどのコンポーネントが描画される */}
                     <Outlet />
                 </div>
+            </div>
+
+            <div className="fixed bottom-6 right-6 z-50">
+                <TooltipProvider>
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <Button
+                                variant="outline"
+                                className="h-10 px-4 rounded-full shadow-md bg-background border-muted-foreground/20 hover:bg-accent hover:text-accent-foreground transition-all flex items-center gap-2 group"
+                                onClick={handleContactClick}
+                            >
+                                <QuestionMarkCircleIcon className="h-5 w-5 text-muted-foreground group-hover:text-foreground transition-colors" />
+                                <span className="text-sm font-medium">{texts.contact}</span>
+                                <ArrowTopRightOnSquareIcon className="h-3 w-3 text-muted-foreground/60" />
+                            </Button>
+                        </TooltipTrigger>
+                        <TooltipContent side="left" className="bg-popover text-popover-foreground border shadow-sm">
+                            <p>{texts.contact}</p>
+                        </TooltipContent>
+                    </Tooltip>
+                </TooltipProvider>
             </div>
         </div>
     );

--- a/src/pages/Auth/SignupPage.tsx
+++ b/src/pages/Auth/SignupPage.tsx
@@ -57,7 +57,7 @@ const SignupPage = () => {
         defaultValues: {
             email: '',
             password: '',
-            timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+            timezone: 'Asia/Tokyo',
             theme_color: theme,
             language: language,
         },

--- a/src/pages/Auth/VerifyPage.tsx
+++ b/src/pages/Auth/VerifyPage.tsx
@@ -64,12 +64,12 @@ const VerifyPage = () => {
         <AuthThemeProvider>
             <Card>
                 <CardHeader>
-                    <CardTitle>{texts.verifyTitle}</CardTitle>
-                    <CardDescription>
-                        {texts.verifySubtitle}
+                    <CardTitle>{texts.emailSentTitle}</CardTitle>
+                    <CardDescription className="whitespace-pre-wrap">
+                        {texts.emailSentDetail.replace('{{email}}', email)}
                     </CardDescription>
                 </CardHeader>
-                <CardContent>
+                <CardContent className="space-y-6">
                     <div className="flex justify-center">
                         <InputOTP
                             maxLength={6}
@@ -87,8 +87,27 @@ const VerifyPage = () => {
                             </InputOTPGroup>
                         </InputOTP>
                     </div>
+
+                    <div className="space-y-4 text-sm text-muted-foreground border-t pt-6">
+                        <p className="font-medium text-foreground">{texts.otpInstructionsTitle}</p>
+                        
+                        <div className="space-y-2">
+                            <p className="font-medium text-foreground">{texts.otpCheckSpamTitle}</p>
+                            <p>{texts.otpCheckSpamDetail}</p>
+                        </div>
+
+                        <div className="space-y-2">
+                            <p className="font-medium text-foreground">{texts.otpCheckEmailTitle}</p>
+                            <p>{texts.otpCheckEmailDetail}</p>
+                        </div>
+
+                        <div className="space-y-2">
+                            <p className="font-medium text-foreground">{texts.otpStillNotReceivedTitle}</p>
+                            <p>{texts.otpStillNotReceivedDetail}</p>
+                        </div>
+                    </div>
                 </CardContent>
-                <CardFooter className="flex justify-between">
+                <CardFooter className="flex justify-between border-t pt-6">
                     <Button variant="outline" onClick={() => navigate('/signup')} disabled={isVerifying}>
                         {texts.back}
                     </Button>

--- a/src/store/authLanguageStore.ts
+++ b/src/store/authLanguageStore.ts
@@ -99,6 +99,19 @@ export interface AuthTexts {
     loginErrorDescription: string;
     signupErrorDescription: string;
     verificationErrorDescription: string;
+
+    // 認証コード送信後の詳細説明
+    emailSentTitle: string;
+    emailSentDetail: string;
+    otpInstructionsTitle: string;
+    otpCheckSpamTitle: string;
+    otpCheckSpamDetail: string;
+    otpCheckEmailTitle: string;
+    otpCheckEmailDetail: string;
+    otpStillNotReceivedTitle: string;
+    otpStillNotReceivedDetail: string;
+
+    contact: string;
 }
 
 const japaneseTexts: AuthTexts = {
@@ -166,6 +179,19 @@ const japaneseTexts: AuthTexts = {
     loginErrorDescription: 'メールアドレスとパスワードを確認してください。',
     signupErrorDescription: 'このメールアドレスはすでに使用されています。',
     verificationErrorDescription: 'コードが正しくないか、期限切れです。',
+
+    // 認証コード送信後の詳細説明
+    emailSentTitle: 'メールを送信しました',
+    emailSentDetail: '{{email}} 宛に認証番号を記載したメールをお送りしました。',
+    otpInstructionsTitle: '数分待っても届かない場合は、以下をご確認ください。',
+    otpCheckSpamTitle: '・迷惑メールフォルダを確認する',
+    otpCheckSpamDetail: 'プロモーションやゴミ箱フォルダに振り分けられている場合があります。',
+    otpCheckEmailTitle: '・メールアドレスに間違いがないか確認する',
+    otpCheckEmailDetail: '入力したアドレスが正しいか、もう一度お確かめください。',
+    otpStillNotReceivedTitle: '上記を確認しても届かない場合',
+    otpStillNotReceivedDetail: '通信状況により到着が遅れることがあります。数分待っても届かない場合は、お手数ですが新規登録画面に戻り、最初からお手続きをお願いします。',
+
+    contact: 'フィードバックを送信',
 };
 
 const englishTexts: AuthTexts = {
@@ -233,6 +259,19 @@ const englishTexts: AuthTexts = {
     loginErrorDescription: 'Please check your email and password.',
     signupErrorDescription: 'This email address is already in use.',
     verificationErrorDescription: 'The code is incorrect or has expired.',
+
+    // 認証コード送信後の詳細説明
+    emailSentTitle: 'Email Sent',
+    emailSentDetail: 'We’ve sent a verification code to {{email}}.',
+    otpInstructionsTitle: 'If you don’t receive it within a few minutes, please try the following:',
+    otpCheckSpamTitle: 'Check your spam folder',
+    otpCheckSpamDetail: 'It might have been filtered into your Junk, Promotions, or Trash folders.',
+    otpCheckEmailTitle: 'Verify your email address',
+    otpCheckEmailDetail: 'Please double-check that the address you entered is correct.',
+    otpStillNotReceivedTitle: "Still haven't received it?",
+    otpStillNotReceivedDetail: 'Delivery can sometimes be delayed. If it still doesn\'t arrive, please go back to the Sign-up screen and try the process again from the beginning.',
+
+    contact: 'Send Feedback',
 };
 
 // 現在の言語設定に基づいてテキストを取得するフック


### PR DESCRIPTION
## 概要
- 認証メールが届かない場合の案内を表示。
- 新規登録時のタイムゾーンの初期値をAsia/Tokyoに設定。
- 未ログイン状態のユーザーでもフィードバックを送信できるよう、共通レイアウトにも「フィードバックを送信」ボタンを追加（Sidebarに表示してるものを流用）。

## 関連
#114 

## その他変更点
- authLanguageStoreに、今回の変更に必要な日英それぞれのテキストを追加。