### PR TITLE
Fix/#121/prevent api requests before login(本番統合)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,7 +33,7 @@ const ProtectedRoute = () => {
   const { isAuthenticated, isUserLoading } = useAuth();
 
   if (isUserLoading) {
-    return <AppLayout />;
+    return <LoadingPage />;
   }
 
   if (!isAuthenticated) {

--- a/src/pages/App/HomePage.tsx
+++ b/src/pages/App/HomePage.tsx
@@ -30,9 +30,12 @@ import { ClockIcon, Cog8ToothIcon, DocumentIcon, InboxIcon, InboxStackIcon, Plus
 import { SortDropdown } from '@/components/shared/SortDropdown';
 
 
+import { useAuth } from '@/hooks/useAuth';
+
 const HomePage = () => {
     const { t } = useTranslation();
     const navigate = useNavigate();
+    const { isAuthenticated } = useAuth();
     const { setCategories } = useCategoryStore();
 
     // モーダルの開閉状態を一元管理
@@ -44,13 +47,13 @@ const HomePage = () => {
     // useQueriesを使い、ホームページに必要なデータを並列で取得
     const results = useQueries({
         queries: [
-            { queryKey: ['categories'], queryFn: fetchCategories },
-            { queryKey: ['summary', 'totalDailyReviewCount'], queryFn: fetchTotalDailyReviewCount },
-            { queryKey: ['summary', 'unclassifiedItemCount'], queryFn: fetchUnclassifiedItemCount },
-            { queryKey: ['summary', 'itemCountByBox'], queryFn: fetchItemCountByBox },
-            { queryKey: ['summary', 'unclassifiedItemCountByCategory'], queryFn: fetchUnclassifiedItemCountByCategory },
-            { queryKey: ['summary', 'dailyReviewCountByBox'], queryFn: fetchDailyReviewCountByBox },
-            { queryKey: ['summary', 'dailyUnclassifiedReviewCountByCategory'], queryFn: fetchDailyUnclassifiedReviewCountByCategory },
+            { queryKey: ['categories'], queryFn: fetchCategories, enabled: isAuthenticated },
+            { queryKey: ['summary', 'totalDailyReviewCount'], queryFn: fetchTotalDailyReviewCount, enabled: isAuthenticated },
+            { queryKey: ['summary', 'unclassifiedItemCount'], queryFn: fetchUnclassifiedItemCount, enabled: isAuthenticated },
+            { queryKey: ['summary', 'itemCountByBox'], queryFn: fetchItemCountByBox, enabled: isAuthenticated },
+            { queryKey: ['summary', 'unclassifiedItemCountByCategory'], queryFn: fetchUnclassifiedItemCountByCategory, enabled: isAuthenticated },
+            { queryKey: ['summary', 'dailyReviewCountByBox'], queryFn: fetchDailyReviewCountByBox, enabled: isAuthenticated },
+            { queryKey: ['summary', 'dailyUnclassifiedReviewCountByCategory'], queryFn: fetchDailyUnclassifiedReviewCountByCategory, enabled: isAuthenticated },
         ],
     });
 
@@ -135,6 +138,7 @@ const HomePage = () => {
         queryKey: ['patterns'],
         queryFn: fetchPatterns,
         staleTime: 1000 * 60 * 5,
+        enabled: isAuthenticated,
     });
 
     return (

--- a/src/pages/App/PatternsPage.tsx
+++ b/src/pages/App/PatternsPage.tsx
@@ -14,8 +14,12 @@ import { EditPatternModal } from '@/components/modals/EditPatternModal';
 import { ScrollArea, ScrollBar } from '@/components/ui/scroll-area';
 
 
+import { useAuth } from '@/hooks/useAuth';
+
+
 const PatternsPage = () => {
     const { t } = useTranslation();
+    const { isAuthenticated } = useAuth();
     const { patterns, setPatterns } = usePatternStore();
 
     // 編集モーダルを開くために、どのパターンを編集中か管理するstate
@@ -31,6 +35,7 @@ const PatternsPage = () => {
         retry: 1,
         refetchOnMount: true,
         refetchOnWindowFocus: false,
+        enabled: isAuthenticated,
     });
 
     // データ取得成功時に、Zustandストアの状態を更新


### PR DESCRIPTION
## 概要
未ログイン状態に、認証が必要なリソースAPI（`/patterns`, `/summary/*` 等）が不適切に呼び出されていた問題を修正。

## 関連
#121 

## 原因
1. [ProtectedRoute](cci:1://file:///Users/yamamotomashiro/workspace/github/review-setter-client/src/App.tsx:30:0-43:2) が認証確認中（`isUserLoading`）であっても [AppLayout](cci:1://file:///Users/yamamotomashiro/workspace/github/review-setter-client/src/components/layout/AppLayout.tsx:12:0-95:2) をレンダリングしており、子コンポーネント（[HomePage](cci:1://file:///Users/yamamotomashiro/workspace/github/review-setter-client/src/pages/App/HomePage.tsx:34:0-271:2) 等）が先行してマウントされていた。
2. 各ページのデータ取得クエリに、認証済みであることを条件とするガードがなかった。

## 変更内容
- **[App.tsx](cci:7://file:///Users/yamamotomashiro/workspace/github/review-setter-client/src/App.tsx:0:0-0:0)**: [ProtectedRoute](cci:1://file:///Users/yamamotomashiro/workspace/github/review-setter-client/src/App.tsx:30:0-43:2) で認証確認中は `LoadingPage` を表示し、認証が必要なコンポーネントをマウントさせないように修正。
- **[HomePage.tsx](cci:7://file:///Users/yamamotomashiro/workspace/github/review-setter-client/src/pages/App/HomePage.tsx:0:0-0:0) / [PatternsPage.tsx](cci:7://file:///Users/yamamotomashiro/workspace/github/review-setter-client/src/pages/App/PatternsPage.tsx:0:0-0:0)**: `useQuery` / `useQueries` に `enabled: isAuthenticated` オプションを追加し、認証確定後のみリクエストが飛ぶように制御。

## 動作確認
- [x] 未ログイン状態で `/` にアクセスした際、`/user` 以外のAPIが呼ばれないこと。
- [x] 認証確認後、未ログインなら `/login` へ正しくリダイレクトされること。
- [x] ログイン済みの場合、認証確定後に一斉リクエストが走り、正常に表示されること。
